### PR TITLE
fix: remove QSS size overrides that cap icon/button sizes at 20px

### DIFF
--- a/examples/qt_button_icon.py
+++ b/examples/qt_button_icon.py
@@ -44,7 +44,6 @@ for _index, preset in enumerate(ty.get_args(QtaSizePreset)):
     btn = QtImagePushButton()
     btn.set_qta("happy")
     btn.set_qta_size_preset(preset)
-    btn.setStyleSheet("QWidget { background-color: red; }")
     row_layout.addWidget(btn)
 
 

--- a/examples/qt_button_icon.py
+++ b/examples/qt_button_icon.py
@@ -1,8 +1,11 @@
 """QtIconButtons."""
 
+import typing as ty
+
 from qtpy.QtWidgets import QApplication, QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from qtextra.config import THEMES
+from qtextra.typing import QtaSizePreset
 from qtextra.widgets.qt_button_icon import (
     QtAndOrButton,
     QtAnimationPlayButton,
@@ -11,6 +14,7 @@ from qtextra.widgets.qt_button_icon import (
     QtFullscreenButton,
     QtHorizontalDirectionButton,
     QtImageButton,
+    QtImagePushButton,
     QtLockButton,
     QtMinimizeButton,
     QtPauseButton,
@@ -31,6 +35,18 @@ THEMES.apply(widget)
 
 layout = QVBoxLayout()
 widget.setLayout(layout)
+
+# Label sizing
+layout.addWidget(QLabel("Buttons sizes"))
+row_layout = QHBoxLayout()
+layout.addLayout(row_layout)
+for _index, preset in enumerate(ty.get_args(QtaSizePreset)):
+    btn = QtImagePushButton()
+    btn.set_qta("happy")
+    btn.set_qta_size_preset(preset)
+    btn.setStyleSheet("QWidget { background-color: red; }")
+    row_layout.addWidget(btn)
+
 
 # single-state buttons can only swap between two states
 layout.addWidget(QLabel("Single-state buttons"))

--- a/examples/qt_label_icon.py
+++ b/examples/qt_label_icon.py
@@ -1,10 +1,13 @@
 """QtQtaLabel."""
 
+import typing as ty
+
 from qtpy.QtWidgets import QApplication, QGridLayout, QHBoxLayout, QVBoxLayout, QWidget
 
 from qtextra._example_helpers import divider, section
 from qtextra.assets import get_icon
 from qtextra.config import THEMES
+from qtextra.typing import QtaSizePreset
 from qtextra.widgets.qt_label_icon import QtPulsingAttentionLabel, QtQtaLabel, QtWarningPulseLabel
 
 app = QApplication([])
@@ -39,6 +42,21 @@ for qta_name, theme_color in [
     label.setToolTip(f"Pulsing attention — {qta_name}")
     active_layout.addWidget(label)
 active_layout.addStretch(1)
+main_layout.addWidget(divider())
+
+# Label sizing
+main_layout.addWidget(section("Label sizes"))
+grid = QGridLayout()
+grid.setHorizontalSpacing(12)
+grid.setVerticalSpacing(8)
+main_layout.addLayout(grid)
+qta_name, qta_kws = get_icon("happy")
+for index, preset in enumerate(ty.get_args(QtaSizePreset)):
+    label = QtQtaLabel()
+    label.set_qta(qta_name, **qta_kws)
+    label.setToolTip(f"happy :: {qta_name} :: {preset}")
+    label.set_qta_size_preset(preset)
+    grid.addWidget(label, index // 6, index % 6)
 main_layout.addWidget(divider())
 
 # General labels

--- a/src/qtextra/assets/__init__.py
+++ b/src/qtextra/assets/__init__.py
@@ -195,6 +195,7 @@ QTA_MAPPING: dict[str, IconType] = {
     "dev": "mdi6.code-braces",
     "import": "mdi.file-import",
     "export": "mdi.file-export",
+    "pop_out": "fa6s.arrow-up-right-from-square",
     # arrows
     "arrow_up": "fa5s.arrow-up",
     "arrow_down": "fa5s.arrow-down",

--- a/src/qtextra/assets/stylesheets/01_buttons.qss
+++ b/src/qtextra/assets/stylesheets/01_buttons.qss
@@ -1,9 +1,5 @@
 /* ----------------- QtImagePushButton ----------------- */
 QtImagePushButton{
-    min-width : 20px;
-    max-width : 20px;
-    min-height : 20px;
-    max-height : 20px;
     padding: 1px;
     border: 1px;
     margin: 1px;

--- a/src/qtextra/assets/stylesheets/02_icons.qss
+++ b/src/qtextra/assets/stylesheets/02_icons.qss
@@ -1,9 +1,5 @@
 /* ----------------- QtIconLabel ----------------- */
 QtIconLabel{
-    min-width : 20px;
-    max-width : 20px;
-    min-height : 20px;
-    max-height : 20px;
     padding: 0px;
     border: 0px;
 }

--- a/src/qtextra/widgets/_qta_mixin.py
+++ b/src/qtextra/widgets/_qta_mixin.py
@@ -17,6 +17,7 @@ from qtextra.typing import QtaSizePreset
 class QtaMixin:
     """Mixin class for Qta widgets."""
 
+    QTA_ICON_SIZE_FOLLOWS_WIDGET_SIZE: ty.ClassVar[bool] = False
     QTA_SIZE_MAP: ty.ClassVar[dict[QtaSizePreset, tuple[QSize, QSize]]] = {
         "xxsmall": (QSize(10, 10), QSize(10, 10)),
         "xsmall": (QSize(16, 16), QSize(16, 16)),
@@ -47,10 +48,13 @@ class QtaMixin:
     def _get_qta_size_spec(cls, preset: QtaSizePreset) -> tuple[QSize, QSize]:
         """Return the widget and icon size for a preset."""
         try:
-            return cls.QTA_SIZE_MAP[preset]
+            widget_size, icon_size = cls.QTA_SIZE_MAP[preset]
         except KeyError as exc:
             presets = ", ".join(cls.QTA_SIZE_MAP)
             raise ValueError(f"Unknown qta size preset '{preset}'. Expected one of: {presets}.") from exc
+        if cls.QTA_ICON_SIZE_FOLLOWS_WIDGET_SIZE:
+            return QSize(widget_size), QSize(widget_size)
+        return QSize(widget_size), QSize(icon_size)
 
     @classmethod
     def _normalize_qta_size(cls, size: int | QSize | tuple[int, int]) -> QSize:

--- a/src/qtextra/widgets/qt_button_icon.py
+++ b/src/qtextra/widgets/qt_button_icon.py
@@ -56,6 +56,7 @@ class QtImagePushButton(QPushButton, QtaMixin):
     def __init__(self, *args: ty.Any, **kwargs: ty.Any):
         self._icon_color = kwargs.pop("icon_color_override", None)
         super().__init__()
+        self.setFixedSize(20, 20)
         self.setProperty("transparent", False)
         self.transparent = False
         with suppress(RuntimeError):

--- a/src/qtextra/widgets/qt_label_icon.py
+++ b/src/qtextra/widgets/qt_label_icon.py
@@ -111,6 +111,7 @@ class QtIconLabel(QLabel):
 class QtQtaLabel(QtIconLabel, QtaMixin):
     """Label."""
 
+    QTA_ICON_SIZE_FOLLOWS_WIDGET_SIZE = True
     _icon = None
 
     def __init__(
@@ -128,7 +129,10 @@ class QtQtaLabel(QtIconLabel, QtaMixin):
         **kwargs,
     ):
         super().__init__("", *args, **kwargs)
-        self._size = QSize(28, 28)
+        self._size = QSize(20, 20)
+        self.setMinimumSize(self._size)
+        self.setMaximumSize(self._size)
+        super().setScaledContents(False)
         self.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignHCenter)
         self.set_default_size(
             xxsmall=xxsmall,
@@ -160,11 +164,22 @@ class QtQtaLabel(QtIconLabel, QtaMixin):
         self._icon = _icon
         self._update_pixmap()
 
-    def setIconSize(self, size: QSize) -> None:
-        """Set icon size."""
-        self._size = QSize(size)
+    def iconSize(self) -> QSize:
+        """Return the requested icon size."""
+        return QSize(self._size)
+
+    def setIconSize(self, size: int | QSize | tuple[int, int]) -> None:
+        """Set icon size and resize the label to match."""
+        self._size = self._normalize_qta_size(size)
+        self.setMinimumSize(self._size)
+        self.setMaximumSize(self._size)
+        self.resize(self._size)
         self._update_pixmap()
         self.updateGeometry()
+
+    def setScaledContents(self, enable: bool) -> None:  # type: ignore[override]
+        """Ignore QLabel pixmap scaling so the requested icon size stays visible."""
+        super().setScaledContents(False)
 
     def update(self, *args: ty.Any, **kwargs: ty.Any) -> None:
         """Update label."""

--- a/src/qtextra/widgets/qt_tooltip_rich.py
+++ b/src/qtextra/widgets/qt_tooltip_rich.py
@@ -227,7 +227,6 @@ class _RichToolTipContent(QFrame):
 
         if icon:
             icon_lbl = hp.make_qta_label(self, icon, size_preset="small")
-            icon_lbl.setScaledContents(True)
             header.addWidget(icon_lbl, 0, Qt.AlignmentFlag.AlignVCenter)
 
         if title:

--- a/tests/widgets/test_qt_label_icon.py
+++ b/tests/widgets/test_qt_label_icon.py
@@ -82,7 +82,7 @@ def test_qt_qta_label_sets_icon_and_size(qapp, qtbot):
     assert widget.pixmap() is not None
     assert widget.minimumSize() == QSize(40, 40)
     assert widget.maximumSize() == QSize(40, 40)
-    assert widget._size == QSize(32, 32)
+    assert widget._size == QSize(40, 40)
     assert widget.objectName() == ""
 
 
@@ -112,6 +112,33 @@ def test_qt_qta_label_set_square_qta_size_from_int(qapp, qtbot):
     assert widget._size == QSize(26, 26)
 
 
+def test_qt_qta_label_accepts_tuple_icon_size_and_reports_icon_size(qapp, qtbot):
+    widget = QtQtaLabel()
+    qtbot.addWidget(widget)
+    widget.set_qta("help")
+
+    widget.setIconSize((30, 18))
+
+    assert widget.iconSize() == QSize(30, 18)
+    assert widget._size == QSize(30, 18)
+    assert widget.pixmap() is not None
+    assert widget.pixmap().deviceIndependentSize().toSize() == QSize(30, 18)
+
+
+def test_qt_qta_label_preset_icon_size_matches_widget_size(qapp, qtbot):
+    widget = QtQtaLabel()
+    qtbot.addWidget(widget)
+    widget.set_qta("help")
+
+    widget.set_qta_size_preset("large")
+
+    assert widget.minimumSize() == QSize(40, 40)
+    assert widget.maximumSize() == QSize(40, 40)
+    assert widget.iconSize() == QSize(40, 40)
+    assert widget.pixmap() is not None
+    assert widget.pixmap().deviceIndependentSize().toSize() == QSize(40, 40)
+
+
 def test_qt_qta_label_pixmap_respects_contents_rect(qapp, qtbot):
     widget = QtQtaLabel()
     qtbot.addWidget(widget)
@@ -136,7 +163,22 @@ def test_qt_qta_label_update_qta_preserves_size(qapp, qtbot):
 
     assert widget.minimumSize() == QSize(40, 40)
     assert widget.maximumSize() == QSize(40, 40)
-    assert widget._size == QSize(32, 32)
+    assert widget._size == QSize(40, 40)
+
+
+def test_qt_qta_label_ignores_scaled_contents_to_preserve_icon_size(qapp, qtbot):
+    widget = QtQtaLabel()
+    qtbot.addWidget(widget)
+    widget.set_qta("help")
+    widget.resize(64, 64)
+
+    widget.setScaledContents(True)
+    widget.setIconSize(QSize(18, 18))
+
+    assert widget.hasScaledContents() is False
+    assert widget.iconSize() == QSize(18, 18)
+    assert widget.pixmap() is not None
+    assert widget.pixmap().deviceIndependentSize().toSize() == QSize(18, 18)
 
 
 def test_qta_size_deprecations_warn_and_preserve_legacy_object_name(qapp, qtbot):
@@ -147,7 +189,7 @@ def test_qta_size_deprecations_warn_and_preserve_legacy_object_name(qapp, qtbot)
         widget.set_default_size(large=True)
     assert widget.objectName() == "large_icon"
     assert widget.minimumSize() == QSize(40, 40)
-    assert widget._size == QSize(32, 32)
+    assert widget._size == QSize(40, 40)
 
     with pytest.deprecated_call(match="set_large"):
         widget.set_large()
@@ -172,7 +214,7 @@ def test_make_qta_helpers_warn_for_legacy_size_flags(qapp, qtbot):
     qtbot.addWidget(label)
     assert label.minimumSize() == QSize(40, 40)
     assert label.maximumSize() == QSize(40, 40)
-    assert label._size == QSize(32, 32)
+    assert label._size == QSize(40, 40)
 
 
 def test_qt_qta_notification_label_validates_state(qapp, qtbot):


### PR DESCRIPTION
The root cause of icons ignoring requested sizes was that QSS rules in 02_icons.qss and 01_buttons.qss forced max-width/max-height of 20px on QtIconLabel and QtImagePushButton, overriding any programmatic setMinimumSize/setMaximumSize calls from _apply_qta_size.

Changes:
- Remove min/max size constraints from QSS for QtIconLabel and QtImagePushButton (keep cosmetic-only props: padding, border, margin)
- Set sensible code-level default sizes in QtQtaLabel.__init__ (20x20) and QtImagePushButton.__init__ (20x20) to replace QSS defaults
- Make QtQtaLabel.setIconSize also resize the widget to match, since the icon IS the label content
- Add QTA_ICON_SIZE_FOLLOWS_WIDGET_SIZE to QtaMixin so label presets use widget size for both widget and icon dimensions
- Block setScaledContents(True) on QtQtaLabel to prevent size flattening
- Add example scripts showing all preset sizes for labels and buttons