### PR TITLE
Fix QtImagePushButton badge sizing

### DIFF
--- a/src/qtextra/assets/stylesheets/03_qta.qss
+++ b/src/qtextra/assets/stylesheets/03_qta.qss
@@ -1,8 +1,3 @@
-QtImagePushButton#normal_icon[with_count=true] {
-    min-width: 30px;
-    max-width: 30px;
-}
-
 QtImagePushButton[checkable=true]::checked {
     background: {{ darken_or_lighten(background, 30) }};
 }

--- a/src/qtextra/widgets/qt_button_icon.py
+++ b/src/qtextra/widgets/qt_button_icon.py
@@ -143,30 +143,17 @@ class QtImagePushButton(QPushButton, QtaMixin):
             return "lg"
         return "xl"
 
-    def _badge_reserved_size(self) -> QSize:
-        """Return the extra (width, height) reserved in the button for the badge."""
-        if self._badge is None or not self._badge.state:
-            return QSize(0, 0)
-        badge_hint = self._badge.sizeHint()
-        # Reserve the badge's own size (plus a 2 px breathing-room) on top and right.
-        return QSize(badge_hint.width() + 2, badge_hint.height() + 2)
-
     def _refresh_button_footprint(self) -> None:
-        """Resize the button so the badge fits at the top-right without clipping the icon."""
-        reserve = self._badge_reserved_size()
-        total = QSize(
-            self._base_button_size.width() + reserve.width(),
-            self._base_button_size.height() + reserve.height(),
-        )
-        QPushButton.setMinimumSize(self, total)
-        QPushButton.setMaximumSize(self, total)
-        # Push the icon into the original bottom-left sub-rect so it doesn't drift when
-        # the badge appears or disappears.
-        self.setContentsMargins(0, reserve.height(), reserve.width(), 0)
+        """Refresh the badge overlay without changing the button footprint."""
+        self.setContentsMargins(0, 0, 0, 0)
+        if self._badge is not None:
+            self._badge.set_badge_size(self._preset_to_badge_size())
+            self._badge._relayout()
+            self._badge._sync_visibility()
         self.updateGeometry()
 
     def setFixedSize(self, *args: ty.Any, **kwargs: ty.Any) -> None:  # type: ignore[override]
-        """Capture the base button footprint; badge reservation is added on top."""
+        """Capture and apply the fixed button footprint."""
         if len(args) == 1 and isinstance(args[0], QSize):
             self._base_button_size = QSize(args[0])
         elif len(args) == 2:
@@ -176,6 +163,7 @@ class QtImagePushButton(QPushButton, QtaMixin):
             self._base_button_size = QSize(self.minimumSize())
             self._refresh_button_footprint()
             return
+        super().setFixedSize(self._base_button_size)
         self._refresh_button_footprint()
 
     def _apply_qta_size(  # type: ignore[override]
@@ -186,7 +174,7 @@ class QtImagePushButton(QPushButton, QtaMixin):
         preset: QtaSizePreset | None = None,
         use_legacy_object_name: bool = False,
     ) -> None:
-        """Apply size and keep the badge size + button footprint in sync with the preset."""
+        """Apply size and keep the badge overlay in sync with the preset."""
         self._base_button_size = QSize(widget_size)
         super()._apply_qta_size(
             widget_size,

--- a/src/qtextra/widgets/qt_notification_badge.py
+++ b/src/qtextra/widgets/qt_notification_badge.py
@@ -103,6 +103,7 @@ class QtNotificationBadge(QtOverlay):
             raise ValueError(f"Invalid mode: {mode}. Must be one of {self.MODES}")
         self._mode = mode
         self.updateGeometry()
+        self._relayout()
         self._sync_visibility()
         self.update()
 
@@ -119,6 +120,8 @@ class QtNotificationBadge(QtOverlay):
         diameter = self._diameter
         self.setMinimumSize(QSize(diameter, diameter))
         self.updateGeometry()
+        self._relayout()
+        self._sync_visibility()
         self.update()
 
     @property
@@ -134,6 +137,7 @@ class QtNotificationBadge(QtOverlay):
             raise ValueError("Badge count must be >= 0")
         self._count = int(count)
         self.updateGeometry()
+        self._relayout()
         self._sync_visibility()
         self.update()
 
@@ -230,11 +234,25 @@ class QtNotificationBadge(QtOverlay):
         return font
 
     def _sync_visibility(self) -> None:
-        has_widget = self.widget() is not None
         should_show = (
-            has_widget and bool(self._state) and (self._mode == "dot" or self._count > 0 or self._visible_when_zero)
+            self._anchor_is_visible()
+            and bool(self._state)
+            and (self._mode == "dot" or self._count > 0 or self._visible_when_zero)
         )
         self.setVisible(should_show)
+
+    def _sync_to_anchor(self) -> None:
+        """Sync visibility using both badge state and anchor visibility."""
+        self._sync_visibility()
+
+    def _anchor_is_visible(self) -> bool:
+        widget = self.widget()
+        if widget is None:
+            return False
+        window = self.window()
+        if window is None or window is widget:
+            return widget.isVisible()
+        return widget.isVisible() and window.isVisible() and widget.isVisibleTo(window)
 
     def _on_theme_changed(self) -> None:
         self.update()

--- a/tests/widgets/test_qt_image_button.py
+++ b/tests/widgets/test_qt_image_button.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from qtpy.QtCore import QEvent, Qt
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 from qtextra.widgets.qt_button_icon import (
     PRESET_TO_BADGE_SIZE,
@@ -158,23 +159,53 @@ class TestQtImagePushButton:
         assert widget._badge.badge_size == expected
         assert PRESET_TO_BADGE_SIZE[preset] == expected
 
-    def test_button_grows_when_badge_attached(self, setup_image_widget):
+    def test_button_size_stays_fixed_when_badge_attached(self, setup_image_widget):
         widget = setup_image_widget()
-        base = widget.maximumSize()
+        widget.set_qta_size_preset("normal")
+        base_minimum = widget.minimumSize()
+        base_maximum = widget.maximumSize()
 
         widget.set_count(5)
-        grown = widget.maximumSize()
 
-        assert grown.width() > base.width()
-        assert grown.height() > base.height()
+        assert widget.minimumSize() == base_minimum
+        assert widget.maximumSize() == base_maximum
 
-    def test_button_shrinks_back_when_badge_cleared(self, setup_image_widget):
+    def test_button_size_stays_fixed_when_badge_cleared(self, setup_image_widget):
         widget = setup_image_widget()
-        base = widget.maximumSize()
+        widget.set_qta_size_preset("normal")
+        base_minimum = widget.minimumSize()
+        base_maximum = widget.maximumSize()
         widget.set_count(5)
         widget.clear_badge()
 
-        assert widget.maximumSize() == base
+        assert widget.minimumSize() == base_minimum
+        assert widget.maximumSize() == base_maximum
+
+    def test_badge_visibility_follows_button_visibility(self, qtbot):
+        host = QWidget()
+        layout = QVBoxLayout(host)
+        widget = QtImagePushButton(parent=host)
+        widget.set_qta_size_preset("normal")
+        layout.addWidget(widget)
+        qtbot.addWidget(host)
+        host.show()
+        qtbot.waitExposed(host)
+
+        widget.set_count(5)
+        qtbot.wait(10)
+        assert widget._badge.isVisible() is True
+
+        widget.hide()
+        qtbot.wait(10)
+        assert widget._badge.isVisible() is False
+
+        widget.show()
+        qtbot.wait(10)
+        assert widget._badge.isVisible() is True
+
+        host.hide()
+        qtbot.wait(10)
+        assert widget._badge.isVisible() is False
 
 
 class TestQtAnimationPlayButton:


### PR DESCRIPTION
## Summary
- Keep QtImagePushButton count badges as overlays so enabling counts does not expand button geometry.
- Hide notification badges when their anchor button or parent containers are hidden.
- Remove the with_count stylesheet width override and add regression coverage for badge sizing and visibility.